### PR TITLE
Added `exif` and `imagick` PHP extensions

### DIFF
--- a/apache2/Dockerfile
+++ b/apache2/Dockerfile
@@ -7,7 +7,7 @@ ENV LANG C.UTF-8
 RUN mkdir /run/apache2
 
 RUN apk --no-cache add apache2 php7-apache2 libxml2-dev apache2-utils apache2-mod-wsgi apache2-ssl
-RUN apk --no-cache add php7 php7-dev php7-fpm php7-mysqli php7-opcache php7-gd php7-zlib php7-curl php7-phar php7-json php7-mbstring php7-mcrypt php7-zip php7-pdo php7-pdo_mysql php7-iconv php7-dom php7-session php7-intl php7-soap php7-fileinfo php7-xml php7-ctype
+RUN apk --no-cache add php7 php7-dev php7-fpm php7-mysqli php7-opcache php7-gd php7-zlib php7-curl php7-phar php7-json php7-mbstring php7-mcrypt php7-zip php7-pdo php7-pdo_mysql php7-iconv php7-dom php7-session php7-intl php7-soap php7-fileinfo php7-xml php7-ctype php7-exif php7-imagick
 RUN apk --no-cache add mosquitto mosquitto-dev
 RUN apk --no-cache add mariadb-client
 


### PR DESCRIPTION
# Proposed Changes
Added the `exif` and `imagick` modules since they are recommended for usage with Wordpress.

## Related Issues

> [Wordpress Handbook][wordpress-handbook]

[wordpress-handbook]: https://make.wordpress.org/hosting/handbook/server-environment/#php-extensions
